### PR TITLE
fix battery text widget for large format devices

### DIFF
--- a/packages/SystemUI/res/layout-sw600dp/status_bar_notification_area.xml
+++ b/packages/SystemUI/res/layout-sw600dp/status_bar_notification_area.xml
@@ -128,11 +128,10 @@
                 android:paddingLeft="4dip"
                 android:visibility="gone"
                 />
-            <ImageView
-                android:id="@+id/battery"
-                android:layout_height="wrap_content"
+            <include layout="@layout/battery_cluster_view"
+                android:id="@+id/battery_cluster"
                 android:layout_width="wrap_content"
-                android:paddingLeft="4dip"
+                android:layout_height="wrap_content"
                 />
         </LinearLayout>
     </LinearLayout>


### PR DESCRIPTION
This allows for accurate battery on tablets as well.
