### PR TITLE
GlobalActions: allow power menu to be dynamic

### DIFF
--- a/policy/src/com/android/internal/policy/impl/GlobalActions.java
+++ b/policy/src/com/android/internal/policy/impl/GlobalActions.java
@@ -112,9 +112,10 @@ class GlobalActions implements DialogInterface.OnDismissListener, DialogInterfac
     public void showDialog(boolean keyguardShowing, boolean isDeviceProvisioned) {
         mKeyguardShowing = keyguardShowing;
         mDeviceProvisioned = isDeviceProvisioned;
-        if (mDialog == null) {
-            mDialog = createDialog();
-        }
+        
+        //always update the PowerMenu dialog
+        mDialog = createDialog();
+
         prepareDialog();
 
         mDialog.show();


### PR DESCRIPTION
the code as is works great for exactly one loading of the power menu

steps to reproduce bug:
from clean install, boot, change power menu settings, long hold power button calling GlobalActions(PowerMenu) then back out

now change a power menu setting and long hold power button again. GlobalActions doesn't look for new values because it found the previous alert dialog. This patch forces the power menu to check everything every time it is called.

pros:
+settings are checked on every power menu load

cons:
-I'm assuming they chose this route would be speed of dialog creation but our phones are fast and I don't notice a difference
