### PR TITLE
Update to CM9's backlight config: Separate configuration of auto-brightn...

### DIFF
--- a/services/java/com/android/server/PowerManagerService.java
+++ b/services/java/com/android/server/PowerManagerService.java
@@ -258,6 +258,12 @@ public class PowerManagerService extends IPowerManager.Stub
     private int mAnimationSetting = ANIM_SETTING_OFF;
     private boolean mAnimateCrtOff = false;
     private boolean mAnimateCrtOn = false;
+        // When using software auto-brightness, determines whether (true) button
+	// and keyboard backlights should also be under automatic brightness
+	// control (i.e., for dimmable backlights), or (false) if they should use
+	// hard-coded brightness settings that timeout-to-off in subsequent screen
+	// power states.
+	private boolean mAutobrightnessButtonKeyboard;
 
     // Must match with the ISurfaceComposer constants in C++.
     private static final int ANIM_SETTING_ON = 0x01;
@@ -617,6 +623,8 @@ public class PowerManagerService extends IPowerManager.Stub
         // read settings for auto-brightness
         mUseSoftwareAutoBrightness = resources.getBoolean(
                 com.android.internal.R.bool.config_automatic_brightness_available);
+		mAutoBrightnessButtonKeyboard = mUseSoftwareAutoBrightness && resources.getBoolean(
+				com.android.internal.R.bool.config_autoBrightnessButtonKeyboard);
         if (mUseSoftwareAutoBrightness) {
             mAutoBrightnessLevels = resources.getIntArray(
                     com.android.internal.R.array.config_autoBrightnessLevels);
@@ -822,7 +830,7 @@ public class PowerManagerService extends IPowerManager.Stub
             switch (wl.flags & LOCK_MASK)
             {
                 case PowerManager.FULL_WAKE_LOCK:
-                    if (mUseSoftwareAutoBrightness) {
+                    if (mAutoBrightnessButtonKeyboard) {
                         wl.minState = SCREEN_BRIGHT;
                     } else {
                         wl.minState = (mKeyboardVisible ? ALL_BRIGHT : SCREEN_BUTTON_BRIGHT);
@@ -1189,6 +1197,7 @@ public class PowerManagerService extends IPowerManager.Stub
                     + " mLightSensorButtonBrightness=" + mLightSensorButtonBrightness
                     + " mLightSensorKeyboardBrightness=" + mLightSensorKeyboardBrightness);
             pw.println("  mUseSoftwareAutoBrightness=" + mUseSoftwareAutoBrightness);
+			pw.println("  mAutoBrightnessButtonKeyboard=" + mAutoBrightnessButtonKeyboard);
             pw.println("  mAutoBrightessEnabled=" + mAutoBrightessEnabled);
             mScreenBrightness.dump(pw, "  mScreenBrightness: ");
 
@@ -1768,7 +1777,7 @@ public class PowerManagerService extends IPowerManager.Stub
                 return;
             }
 
-            if (!mBootCompleted && !mUseSoftwareAutoBrightness) {
+            if (!mBootCompleted && !mAutoBrightnessButtonKeyboard) {
                 newState |= ALL_BRIGHT;
             }
 
@@ -2280,7 +2289,7 @@ public class PowerManagerService extends IPowerManager.Stub
         }
         if (mButtonBrightnessOverride >= 0) {
             brightness = mButtonBrightnessOverride;
-        } else if (mLightSensorButtonBrightness >= 0 && mUseSoftwareAutoBrightness) {
+        } else if (mLightSensorButtonBrightness >= 0 && mAutoBrightnessButtonKeyboard) {
             brightness = mLightSensorButtonBrightness;
         }
         if (brightness > 0) {
@@ -2302,7 +2311,7 @@ public class PowerManagerService extends IPowerManager.Stub
             brightness = 0;
         } else if (mButtonBrightnessOverride >= 0) {
             brightness = mButtonBrightnessOverride;
-        } else if (mLightSensorKeyboardBrightness >= 0 && mUseSoftwareAutoBrightness) {
+        } else if (mLightSensorKeyboardBrightness >= 0 && mAutoBrightnessButtonKeyboard) {
             brightness =  mLightSensorKeyboardBrightness;
         }
         if (brightness > 0) {
@@ -2425,9 +2434,11 @@ public class PowerManagerService extends IPowerManager.Stub
             if (mLastEventTime <= time || force) {
                 mLastEventTime = time;
                 if ((mUserActivityAllowed && !mProximitySensorActive) || force) {
-                    // Only turn on button backlights if a button was pressed
-                    // and auto brightness is disabled
-                    if (eventType == BUTTON_EVENT && !mUseSoftwareAutoBrightness) {
+					if (!mAutoBrightnessButtonKeyboard) {
+						// Turn on button (and keyboard) backlights on any event, so that they
+						// don't suddenly disappear when the lock screen is unlocked (OTHER_EVENT),
+						// and so capacitive buttons can be found on devices where they lack
+						// identifying surface features.
                         mUserState = (mKeyboardVisible ? ALL_BRIGHT : SCREEN_BUTTON_BRIGHT);
                     } else {
                         // don't clear button/keyboard backlights when the screen is touched.
@@ -2899,7 +2910,7 @@ public class PowerManagerService extends IPowerManager.Stub
         // wait until sensors are enabled before turning on screen.
         // some devices will not activate the light sensor properly on boot
         // unless we do this.
-        if (mUseSoftwareAutoBrightness) {
+        if (mAutoBrightnessButtonKeyboard) {
             // turn the screen on
             setPowerState(SCREEN_BRIGHT);
         } else {


### PR DESCRIPTION
...ess for button/keyboard backlights. Dependent on /core/res/re/vaules/config.xml commit.

From CM: Presently, light-sensor based automatic brightness
(config_autoBrightnessLevels) controls both button and keyboard backlights
in addition to the screen backlight.  Unfortunately auto-brightness for
button/keyboard backlights doesn't work well on devices (e.g., epicmtd)
with neither (i) dimmable button/keyboard backlights (so when they're on,
they're very bright even if the screen backlight is relatively dark) nor
(ii) identifiable surface features on capacitive buttons (so they can't be
found if the backlights are permanently turned off).
