### PR TITLE
This goes along with the commit for the separate configuration of auto-b...

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -490,6 +490,10 @@
          This must be overridden in platform specific overlays -->
     <integer-array name="config_autoBrightnessLcdBacklightValues">
     </integer-array>
+	
+	<!-- Flag indicating whether we should enable autmatic brightness for
+		 the button and keyboard backlights. -->
+	<bool name="config_autoBrightnessButtonKeyboard">true</bool>
 
     <!-- Array of output values for button backlight corresponding to the LUX values
          in the config_autoBrightnessLevels array.  This array should have size one greater


### PR DESCRIPTION
...rightness for button/keyboard backlights.

Note from CM: This also addressed is a bug that disables the button and keyboard backlights on
screen unlock, and reenables the backlights on touch events so that
capacitive keys may be located.
