### PR TITLE
fix Sync Toggle

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/toggles/SyncToggle.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/toggles/SyncToggle.java
@@ -20,17 +20,29 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SyncStatusObserver;
+import android.os.Handler;
+import android.os.RemoteException;
+import android.view.KeyEvent;
 
 import com.android.systemui.R;
 
 public class SyncToggle extends Toggle {
+	
+	private Handler mHandler = new Handler();
 
     private SyncStatusObserver mSyncObserver = new SyncStatusObserver() {
         public void onStatusChanged(int which) {
-            updateState();
+        	mHandler.post(onSyncUpdated);
+        	// View cannot be updated outside UI thread.  use handler to run update
         }
     };
 
+    final Runnable onSyncUpdated = new Runnable() {
+    	public void run() {
+    		updateState();
+    	}
+    };
+    
     public SyncToggle(Context context) {
         super(context);
         updateState();


### PR DESCRIPTION
SyncObserver callback was running on a separate thread and could not update UI.
Thus, it was crashing the toggle.  I created and handler/runnable to handle the update
so it stays on UI thread.
