### PR TITLE
Fix WeatherPanel Visibility

### DIFF
--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/WeatherPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/WeatherPanel.java
@@ -78,7 +78,7 @@ public class WeatherPanel extends FrameLayout {
                 }
             }
             mUpdateReceived = true;
-            setVisibility(View.VISIBLE);
+            updateSettings();
         }
     };
 


### PR DESCRIPTION
WeatherPanel is visible irrespective of the toggle
state every time weather update is initiated.
