### PR TITLE
navbar fixes & weather modifications

### DIFF
--- a/packages/SystemUI/res/layout-sw600dp/status_bar_notification_panel_title.xml
+++ b/packages/SystemUI/res/layout-sw600dp/status_bar_notification_panel_title.xml
@@ -183,7 +183,7 @@
         android:textColor="#ffffff"
         />
 
-	<com.android.internal.policy.impl.WeatherText
+	<com.android.systemui.statusbar.policy.WeatherText
 		android:id="@+id/weather"
 		style="@style/StatusBarNotificationText"
 		android:layout_height="wrap_content"

--- a/packages/SystemUI/res/layout/status_bar_expanded.xml
+++ b/packages/SystemUI/res/layout/status_bar_expanded.xml
@@ -112,13 +112,13 @@
         		android:layout_width="wrap_content"
         		android:layout_height="wrap_content" />
     		<TextView
-       			android:id="@+id/winds"
+       			android:id="@+id/current_temp"
        			android:textAppearance="@style/TextAppearance.StatusBar.Clock"
         		android:layout_width="wrap_content"
         		android:layout_height="wrap_content" />
 
     		<TextView
-        		android:id="@+id/humidity"
+        		android:id="@+id/condition"
         		android:textAppearance="@style/TextAppearance.StatusBar.Clock"
         		android:layout_width="wrap_content"
                         android:layout_height="wrap_content" />
@@ -140,21 +140,21 @@
         	android:layout_alignParentRight="true">
 
     		<TextView
-        		android:id="@+id/current_temp"
+        		android:id="@+id/high_temp"
         		android:textAppearance="@style/TextAppearance.StatusBar.Clock"
         		android:layout_width="wrap_content" 
             	android:layout_height="wrap_content"
             	android:gravity="right" />
         		
     		<TextView
-       			android:id="@+id/high_temp"
+       			android:id="@+id/low_temp"
        			android:textAppearance="@style/TextAppearance.StatusBar.Clock"
         		android:layout_width="wrap_content" 
             	android:layout_height="wrap_content"
             	android:gravity="right"/>
         	
         	<TextView
-       			android:id="@+id/low_temp"
+       			android:id="@+id/winds"
         		android:textAppearance="@style/TextAppearance.StatusBar.Clock"
         		android:layout_width="wrap_content" 
             	android:layout_height="wrap_content"

--- a/packages/SystemUI/res/layout/status_bar_expanded.xml
+++ b/packages/SystemUI/res/layout/status_bar_expanded.xml
@@ -112,13 +112,13 @@
         		android:layout_width="wrap_content"
         		android:layout_height="wrap_content" />
     		<TextView
-       			android:id="@+id/current_temp"
+       			android:id="@+id/condition"
        			android:textAppearance="@style/TextAppearance.StatusBar.Clock"
         		android:layout_width="wrap_content"
         		android:layout_height="wrap_content" />
 
     		<TextView
-        		android:id="@+id/condition"
+        		android:id="@+id/winds"
         		android:textAppearance="@style/TextAppearance.StatusBar.Clock"
         		android:layout_width="wrap_content"
                         android:layout_height="wrap_content" />
@@ -141,21 +141,21 @@
         	android:layout_alignParentRight="true">
 
     		<TextView
-        		android:id="@+id/high_temp"
+        		android:id="@+id/current_temp"
         		android:textAppearance="@style/TextAppearance.StatusBar.Clock"
         		android:layout_width="wrap_content" 
             	android:layout_height="wrap_content"
             	android:gravity="right" />
         		
     		<TextView
-       			android:id="@+id/low_temp"
+       			android:id="@+id/high_temp"
        			android:textAppearance="@style/TextAppearance.StatusBar.Clock"
         		android:layout_width="wrap_content" 
             	android:layout_height="wrap_content"
             	android:gravity="right"/>
         	
         	<TextView
-       			android:id="@+id/winds"
+       			android:id="@+id/low_temp"
         		android:textAppearance="@style/TextAppearance.StatusBar.Clock"
         		android:layout_width="wrap_content" 
             	android:layout_height="wrap_content"

--- a/packages/SystemUI/res/layout/status_bar_expanded.xml
+++ b/packages/SystemUI/res/layout/status_bar_expanded.xml
@@ -131,17 +131,31 @@
         	android:layout_centerHorizontal="true"
 		android:layout_centerVertical="true" />
         	
-        <LinearLayout
-        	android:orientation="vertical"
-        	android:textAppearance="@style/TextAppearance.StatusBar.Clock"
+        <GridLayout
         	android:layout_width="wrap_content"
         	android:layout_height="match_parent" 
+        	android:columnCount="2"
+        	android:rowCount="3"
         	android:paddingRight="5dp"
         	android:paddingLeft="5dp"
         	android:layout_alignParentRight="true">
+        	
+    		<TextView
+        		android:text="@string/weatherpanel_current"
+        		android:textAppearance="@style/TextAppearance.StatusBar.Clock"
+        		android:layout_width="wrap_content" 
+            	android:layout_height="wrap_content"
+            	android:layout_gravity="right" />
 
     		<TextView
         		android:id="@+id/current_temp"
+        		android:textAppearance="@style/TextAppearance.StatusBar.Clock"
+        		android:layout_width="wrap_content" 
+            	android:layout_height="wrap_content"
+            	android:layout_gravity="right" />
+            	
+    		<TextView
+        		android:text="@string/weatherpanel_high"
         		android:textAppearance="@style/TextAppearance.StatusBar.Clock"
         		android:layout_width="wrap_content" 
             	android:layout_height="wrap_content"
@@ -153,6 +167,13 @@
         		android:layout_width="wrap_content" 
             	android:layout_height="wrap_content"
             	android:layout_gravity="right"/>
+            	
+    		<TextView
+        		android:text="@string/weatherpanel_low"
+        		android:textAppearance="@style/TextAppearance.StatusBar.Clock"
+        		android:layout_width="wrap_content" 
+            	android:layout_height="wrap_content"
+            	android:layout_gravity="right" />
         	
         	<TextView
        			android:id="@+id/low_temp"
@@ -160,7 +181,7 @@
         		android:layout_width="wrap_content" 
             	android:layout_height="wrap_content"
             	android:layout_gravity="right" />
-         </LinearLayout>
+         </GridLayout>
       
       </RelativeLayout>
             	

--- a/packages/SystemUI/res/layout/status_bar_expanded.xml
+++ b/packages/SystemUI/res/layout/status_bar_expanded.xml
@@ -128,7 +128,8 @@
         	android:id="@+id/condition_image"
         	android:layout_width="match_parent"
         	android:layout_height="wrap_content"
-        	android:layout_centerHorizontal="true" />
+        	android:layout_centerHorizontal="true"
+		android:layout_centerVertical="true" />
         	
         <LinearLayout
         	android:orientation="vertical"

--- a/packages/SystemUI/res/layout/status_bar_expanded.xml
+++ b/packages/SystemUI/res/layout/status_bar_expanded.xml
@@ -145,21 +145,21 @@
         		android:textAppearance="@style/TextAppearance.StatusBar.Clock"
         		android:layout_width="wrap_content" 
             	android:layout_height="wrap_content"
-            	android:gravity="right" />
+            	android:layout_gravity="right" />
         		
     		<TextView
        			android:id="@+id/high_temp"
        			android:textAppearance="@style/TextAppearance.StatusBar.Clock"
         		android:layout_width="wrap_content" 
             	android:layout_height="wrap_content"
-            	android:gravity="right"/>
+            	android:layout_gravity="right"/>
         	
         	<TextView
        			android:id="@+id/low_temp"
         		android:textAppearance="@style/TextAppearance.StatusBar.Clock"
         		android:layout_width="wrap_content" 
             	android:layout_height="wrap_content"
-            	android:gravity="right" />
+            	android:layout_gravity="right" />
          </LinearLayout>
       
       </RelativeLayout>

--- a/packages/SystemUI/res/layout/weatherpanel.xml
+++ b/packages/SystemUI/res/layout/weatherpanel.xml
@@ -28,17 +28,17 @@
         android:layout_height="wrap_content" />
 
     <TextView
-        android:id="@+id/zipcode"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content" />
-
-    <TextView
         android:id="@+id/humidity"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
 
     <TextView
         android:id="@+id/winds"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content" />
+        
+    <TextView
+        android:id="@+id/condition"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content" />
 

--- a/packages/SystemUI/res/values/strings.xml
+++ b/packages/SystemUI/res/values/strings.xml
@@ -383,6 +383,9 @@
     <string name="toggle_sync">Sync</string>
     <string name="toggle_swagger">Swagger</string>
     <string name="status_bar_settings_toggles">Toggles</string>
+    <string name="weatherpanel_current">Current: </string>
+    <string name="weatherpanel_low">Low: </string>
+    <string name="weatherpanel_high">High: </string>
     
 	<!-- Title for the pseudo-notification shown when notifications are disabled (do-not-disturb
          mode) -->

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/WeatherPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/WeatherPanel.java
@@ -50,11 +50,11 @@ public class WeatherPanel extends FrameLayout {
         public void onReceive(Context context, Intent intent) {
             mCondition_code = (String) intent.getCharSequenceExtra(EXTRA_CONDITION_CODE);
             if (mCurrentTemp != null)
-                mCurrentTemp.setText("Current: " + intent.getCharSequenceExtra(EXTRA_TEMP));
+                mCurrentTemp.setText(intent.getCharSequenceExtra(EXTRA_TEMP));
             if (mHighTemp != null)
-                mHighTemp.setText("High: " + intent.getCharSequenceExtra(EXTRA_HIGH));
+                mHighTemp.setText(intent.getCharSequenceExtra(EXTRA_HIGH));
             if (mLowTemp != null)
-                mLowTemp.setText("Low: " + intent.getCharSequenceExtra(EXTRA_LOW));
+                mLowTemp.setText(intent.getCharSequenceExtra(EXTRA_LOW));
             if (mCity != null)
                 mCity.setText(intent.getCharSequenceExtra(EXTRA_CITY));
             if (mHumidity != null)

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/WeatherPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/WeatherPanel.java
@@ -28,9 +28,8 @@ public class WeatherPanel extends FrameLayout {
     public static final String EXTRA_ZIP = "zip";
     public static final String EXTRA_CONDITION = "condition";
     public static final String EXTRA_CONDITION_CODE = "condition_code";
-    public static final String EXTRA_FORECAST_DATE = "forecase_date";
-    public static final String EXTRA_TEMP_F = "temp_f";
-    public static final String EXTRA_TEMP_C = "temp_c";
+    public static final String EXTRA_FORECAST_DATE = "forecast_date";
+    public static final String EXTRA_TEMP = "temp";
     public static final String EXTRA_HUMIDITY = "humidity";
     public static final String EXTRA_WIND = "wind";
     public static final String EXTRA_LOW = "todays_low";
@@ -43,6 +42,7 @@ public class WeatherPanel extends FrameLayout {
     private TextView mZipCode;
     private TextView mHumidity;
     private TextView mWinds;
+    private TextView mCondition;
     private ImageView mConditionImage;
     private Context mContext;
     private String mCondition_code = "";
@@ -52,7 +52,7 @@ public class WeatherPanel extends FrameLayout {
         public void onReceive(Context context, Intent intent) {
             mCondition_code = (String) intent.getCharSequenceExtra(EXTRA_CONDITION_CODE);
             if (mCurrentTemp != null)
-                mCurrentTemp.setText("Current:" + intent.getCharSequenceExtra("temp"));
+                mCurrentTemp.setText("Current:" + intent.getCharSequenceExtra(EXTRA_TEMP));
             if (mHighTemp != null)
                 mHighTemp.setText("High:" + intent.getCharSequenceExtra(EXTRA_HIGH));
             if (mLowTemp != null)
@@ -65,6 +65,8 @@ public class WeatherPanel extends FrameLayout {
                 mHumidity.setText(intent.getCharSequenceExtra(EXTRA_HUMIDITY));
             if (mWinds != null)
                 mWinds.setText(intent.getCharSequenceExtra(EXTRA_WIND));
+	    if (mCondition != null)
+                mCondition.setText(intent.getCharSequenceExtra(EXTRA_CONDITION));
             if (mConditionImage != null) {
                 String condition_filename = "weather_" + mCondition_code;
                 int resID = getResources().getIdentifier(condition_filename, "drawable",
@@ -108,6 +110,7 @@ public class WeatherPanel extends FrameLayout {
         mZipCode = (TextView) this.findViewById(R.id.zipcode);
         mHumidity = (TextView) this.findViewById(R.id.humidity);
         mWinds = (TextView) this.findViewById(R.id.winds);
+        mCondition = (TextView) this.findViewById(R.id.condition);
         mConditionImage = (ImageView) this.findViewById(R.id.condition_image);
         if (!mAttached) {
             mAttached = true;

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/WeatherPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/WeatherPanel.java
@@ -50,7 +50,7 @@ public class WeatherPanel extends FrameLayout {
         public void onReceive(Context context, Intent intent) {
             mCondition_code = (String) intent.getCharSequenceExtra(EXTRA_CONDITION_CODE);
             if (mCurrentTemp != null)
-                mCurrentTemp.setText(intent.getCharSequenceExtra(EXTRA_TEMP));
+                mCurrentTemp.setText("Current: " + intent.getCharSequenceExtra(EXTRA_TEMP));
             if (mHighTemp != null)
                 mHighTemp.setText("High: " + intent.getCharSequenceExtra(EXTRA_HIGH));
             if (mLowTemp != null)

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/WeatherPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/WeatherPanel.java
@@ -25,7 +25,6 @@ public class WeatherPanel extends FrameLayout {
     private boolean mUpdateReceived = false;
 
     public static final String EXTRA_CITY = "city";
-    public static final String EXTRA_ZIP = "zip";
     public static final String EXTRA_CONDITION = "condition";
     public static final String EXTRA_CONDITION_CODE = "condition_code";
     public static final String EXTRA_FORECAST_DATE = "forecast_date";
@@ -39,7 +38,6 @@ public class WeatherPanel extends FrameLayout {
     private TextView mLowTemp;
     private TextView mCurrentTemp;
     private TextView mCity;
-    private TextView mZipCode;
     private TextView mHumidity;
     private TextView mWinds;
     private TextView mCondition;
@@ -59,13 +57,11 @@ public class WeatherPanel extends FrameLayout {
                 mLowTemp.setText("Low:" + intent.getCharSequenceExtra(EXTRA_LOW));
             if (mCity != null)
                 mCity.setText(intent.getCharSequenceExtra(EXTRA_CITY));
-            if (mZipCode != null)
-                mZipCode.setText("ZipCode:" + intent.getCharSequenceExtra(EXTRA_ZIP));
             if (mHumidity != null)
                 mHumidity.setText(intent.getCharSequenceExtra(EXTRA_HUMIDITY));
             if (mWinds != null)
                 mWinds.setText(intent.getCharSequenceExtra(EXTRA_WIND));
-	    if (mCondition != null)
+            if (mCondition != null)
                 mCondition.setText(intent.getCharSequenceExtra(EXTRA_CONDITION));
             if (mConditionImage != null) {
                 String condition_filename = "weather_" + mCondition_code;
@@ -107,7 +103,6 @@ public class WeatherPanel extends FrameLayout {
         mLowTemp = (TextView) this.findViewById(R.id.low_temp);
         mCurrentTemp = (TextView) this.findViewById(R.id.current_temp);
         mCity = (TextView) this.findViewById(R.id.city);
-        mZipCode = (TextView) this.findViewById(R.id.zipcode);
         mHumidity = (TextView) this.findViewById(R.id.humidity);
         mWinds = (TextView) this.findViewById(R.id.winds);
         mCondition = (TextView) this.findViewById(R.id.condition);

--- a/packages/SystemUI/src/com/android/systemui/statusbar/policy/WeatherPanel.java
+++ b/packages/SystemUI/src/com/android/systemui/statusbar/policy/WeatherPanel.java
@@ -25,7 +25,6 @@ public class WeatherPanel extends FrameLayout {
     private boolean mUpdateReceived = false;
 
     public static final String EXTRA_CITY = "city";
-    public static final String EXTRA_ZIP = "zip";
     public static final String EXTRA_CONDITION = "condition";
     public static final String EXTRA_CONDITION_CODE = "condition_code";
     public static final String EXTRA_FORECAST_DATE = "forecast_date";
@@ -39,7 +38,6 @@ public class WeatherPanel extends FrameLayout {
     private TextView mLowTemp;
     private TextView mCurrentTemp;
     private TextView mCity;
-    private TextView mZipCode;
     private TextView mHumidity;
     private TextView mWinds;
     private TextView mCondition;
@@ -52,15 +50,13 @@ public class WeatherPanel extends FrameLayout {
         public void onReceive(Context context, Intent intent) {
             mCondition_code = (String) intent.getCharSequenceExtra(EXTRA_CONDITION_CODE);
             if (mCurrentTemp != null)
-                mCurrentTemp.setText("Current:" + intent.getCharSequenceExtra(EXTRA_TEMP));
+                mCurrentTemp.setText(intent.getCharSequenceExtra(EXTRA_TEMP));
             if (mHighTemp != null)
-                mHighTemp.setText("High:" + intent.getCharSequenceExtra(EXTRA_HIGH));
+                mHighTemp.setText("High: " + intent.getCharSequenceExtra(EXTRA_HIGH));
             if (mLowTemp != null)
-                mLowTemp.setText("Low:" + intent.getCharSequenceExtra(EXTRA_LOW));
+                mLowTemp.setText("Low: " + intent.getCharSequenceExtra(EXTRA_LOW));
             if (mCity != null)
                 mCity.setText(intent.getCharSequenceExtra(EXTRA_CITY));
-            if (mZipCode != null)
-                mZipCode.setText("ZipCode:" + intent.getCharSequenceExtra(EXTRA_ZIP));
             if (mHumidity != null)
                 mHumidity.setText(intent.getCharSequenceExtra(EXTRA_HUMIDITY));
             if (mWinds != null)
@@ -107,7 +103,6 @@ public class WeatherPanel extends FrameLayout {
         mLowTemp = (TextView) this.findViewById(R.id.low_temp);
         mCurrentTemp = (TextView) this.findViewById(R.id.current_temp);
         mCity = (TextView) this.findViewById(R.id.city);
-        mZipCode = (TextView) this.findViewById(R.id.zipcode);
         mHumidity = (TextView) this.findViewById(R.id.humidity);
         mWinds = (TextView) this.findViewById(R.id.winds);
         mCondition = (TextView) this.findViewById(R.id.condition);

--- a/policy/src/com/android/internal/policy/impl/GlobalActions.java
+++ b/policy/src/com/android/internal/policy/impl/GlobalActions.java
@@ -839,7 +839,7 @@ class GlobalActions implements DialogInterface.OnDismissListener, DialogInterfac
                 LayoutInflater inflater) {
         	mContext = context;
         	mNavBarHideOn = Settings.System.getInt(mContext.getContentResolver(),
-                    Settings.System.NAVIGATION_BAR_BUTTONS_SHOW, 0) == 0;
+                    Settings.System.NAVIGATION_BAR_BUTTONS_SHOW, 1) == 0;
         	mWindowManager = IWindowManager.Stub.asInterface(ServiceManager.getService("window"));
                  	
             View v = inflater.inflate(R.layout.global_actions_navbar_mode, parent, false);
@@ -880,10 +880,10 @@ class GlobalActions implements DialogInterface.OnDismissListener, DialogInterfac
             switch (index) {
             
             case 0 :
-            	mNavBarHideOn = !mNavBarHideOn;
+                mNavBarHideOn = !mNavBarHideOn;
                 Settings.System.putInt(mContext.getContentResolver(),
                         Settings.System.NAVIGATION_BAR_BUTTONS_SHOW,
-                         mNavBarHideOn ? 1 : 0);
+                         mNavBarHideOn ? 0 : 1);
                 v.setSelected(!mNavBarHideOn);
                 mHandler.sendEmptyMessage(MESSAGE_DISMISS);
                 break;

--- a/policy/src/com/android/internal/policy/impl/GlobalActions.java
+++ b/policy/src/com/android/internal/policy/impl/GlobalActions.java
@@ -846,7 +846,7 @@ class GlobalActions implements DialogInterface.OnDismissListener, DialogInterfac
 
             for (int i = 0; i < 4; i++) {
                 View itemView = v.findViewById(ITEM_IDS[i]);
-                itemView.setSelected((i==0)&&(!mNavBarHideOn));  // set selected on item 0 if NavBarHideOn is off
+                itemView.setSelected((i==0)&&mNavBarHideOn);  // set selected on item 0 if NavBarHideOn is off
                 // Set up click handler
                 itemView.setTag(i);
                 itemView.setOnClickListener(this);
@@ -880,7 +880,6 @@ class GlobalActions implements DialogInterface.OnDismissListener, DialogInterfac
             switch (index) {
             
             case 0 :
-                mNavBarHideOn = !mNavBarHideOn;
                 Settings.System.putInt(mContext.getContentResolver(),
                         Settings.System.NAVIGATION_BAR_BUTTONS_SHOW,
                          mNavBarHideOn ? 0 : 1);

--- a/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
+++ b/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
@@ -1058,8 +1058,9 @@ public class PhoneWindowManager implements WindowManagerPolicy {
             mEnableQuickTorch = Settings.System.getInt(resolver, Settings.System.ENABLE_FAST_TORCH,
                     0) == 1;
             boolean hasNavBarChanged = Settings.System.getInt(resolver, Settings.System.NAVIGATION_BAR_BUTTONS_SHOW,
-                            0) == 1;
+                            1) == 1;
             if (mHasNavigationBar != hasNavBarChanged) {
+                mHasNavigationBar = hasNavBarChanged;
             	setInitialDisplaySize(mUnrestrictedScreenWidth,mUnrestrictedScreenHeight);
             }
 

--- a/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
+++ b/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
@@ -1005,9 +1005,6 @@ public class PhoneWindowManager implements WindowManagerPolicy {
             if      (navBarOverride.equals("1")) mHasNavigationBar = false;
             else if (navBarOverride.equals("0")) mHasNavigationBar = true;
         }
-        // make sure tablets never ever try and use this
-        if(mStatusBarCanHide)
-            mHasNavigationBar = false;
 
         if (mHasNavigationBar) {
             mNavigationBarHeight = Settings.System.getInt(


### PR DESCRIPTION
as we changed from hide to show, we need to use 1 as default return value, instead of 0.
Removed the tablet check in 04bd323, because it triggers on the gnex too, and we don't want that :(
If anyone's navbar doesn't show up, I added a reset to framework line to the "reset navbar" button in romcontrol, so users can reach it via the notification slider's setting button...

agreed with Zaphod to use this layout for the default weatherpanel.
http://dl.dropbox.com/u/7965056/Screenshot_2012-03-02-20-51-19.png
sorry for the lots of commits, it started just as my local weather layout branch, then we decided to merge it and it became part of this pull :P
