### PR TITLE
Fix NavBar on/off at boot

### DIFF
--- a/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
+++ b/policy/src/com/android/internal/policy/impl/PhoneWindowManager.java
@@ -1005,6 +1005,14 @@ public class PhoneWindowManager implements WindowManagerPolicy {
             if      (navBarOverride.equals("1")) mHasNavigationBar = false;
             else if (navBarOverride.equals("0")) mHasNavigationBar = true;
         }
+        
+        if (mNavBarFirstBootFlag){
+        	mHasNavigationBar = (showByDefault == 1);
+        	mNavBarFirstBootFlag = false;
+        	// at first boot up, we need to make sure navbar gets created (or obey framework setting).  
+        	// this should quickly get over-ridden by the settings observer if it was
+        	// disabled by the user.
+        }
         if(!mStatusBarCanHide)
             mHasNavigationBar = false;
 


### PR DESCRIPTION
This allows for NavBar to still be enabled if it was
turned off at boot.
