### PR TITLE
change simple textview to CalendarEntry on lockscreen

### DIFF
--- a/policy/src/com/android/internal/policy/impl/CalendarEntry.java
+++ b/policy/src/com/android/internal/policy/impl/CalendarEntry.java
@@ -1,0 +1,41 @@
+
+package com.android.internal.policy.impl;
+
+import android.content.Context;
+import android.util.Log;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+public class CalendarEntry extends LinearLayout {
+
+    private static final String TAG = "CalendarEntry";
+    TextView mTitle;
+    TextView mDetails;
+
+    public CalendarEntry(Context context, String title, String details, int width) {
+        super(context);
+        this.setOrientation(LinearLayout.HORIZONTAL);
+        this.setGravity(android.view.Gravity.RIGHT);
+        mTitle = new TextView(getContext());
+        mTitle.setLayoutParams(new android.widget.LinearLayout.LayoutParams(0, -2, 1));
+        mTitle.setText(title);
+        mTitle.setTextAppearance(getContext(), android.R.attr.textAppearanceMedium);
+        mTitle.setSingleLine(true);
+        mTitle.setEllipsize(android.text.TextUtils.TruncateAt.END);
+        mTitle.setPadding(0, 0, 2, 0);
+        mTitle.setGravity(android.view.Gravity.RIGHT);
+        mDetails = new TextView(getContext());
+        mDetails.setLayoutParams(new android.widget.LinearLayout.LayoutParams(-2, -2));
+        mDetails.setText(details);
+        mDetails.setTextAppearance(getContext(), android.R.attr.textAppearanceMedium);
+        mDetails.setSingleLine(true);
+        mDetails.setPadding(2, 0, 0, 0);
+        this.addView(mTitle);
+        this.addView(mDetails);
+    }
+
+    public void setColor(int color) {
+        mTitle.setTextColor(color);
+        mDetails.setTextColor(color);
+    }
+}

--- a/policy/src/com/android/internal/policy/impl/KeyguardStatusViewManager.java
+++ b/policy/src/com/android/internal/policy/impl/KeyguardStatusViewManager.java
@@ -37,6 +37,7 @@ import android.util.Log;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.ViewFlipper;
 import android.content.Intent;
@@ -47,7 +48,6 @@ import com.android.internal.telephony.IccCard;
 import com.android.internal.telephony.IccCard.State;
 import com.android.internal.widget.LockPatternUtils;
 import com.android.internal.widget.TransportControlView;
-import com.android.internal.policy.impl.WeatherText;
 
 /***
  * Manages a number of views inside of LockScreen layouts. See below for a list
@@ -473,24 +473,20 @@ class KeyguardStatusViewManager implements OnClickListener {
                 if (calendarEventsEnabled) {
                     mCalendarView.removeAllViews();
                     Log.d(TAG, "we have " + String.valueOf(mCalendarEvents.size()) + " event(s)");
+                    int dateWidth = (int) (findViewById(R.id.time).getWidth() * 1.2);
 
                     for (EventBundle e : mCalendarEvents) {
-                        TextView tv = new TextView(getContext());
-                        tv.setText(e.title
-                                + (!e.dayString.isEmpty() ? e.dayString : "")
-                                + ((e.allDay) ? " all-day " : " at "
-                                        + DateFormat.format(
-                                                DateFormat.is24HourFormat(getContext()) ? "kk:mm"
-                                                        : "hh:mm a", e.begin).toString())
-                                + (!e.location.isEmpty() ? " (" + e.location + ")" : ""));
-                        tv.setTextAppearance(getContext(), android.R.attr.textAppearanceMedium);
-                        tv.setWidth((int) (findViewById(R.id.time).getWidth() * 1.2));
-                        tv.setSingleLine(true);
-                        tv.setEllipsize(android.text.TextUtils.TruncateAt.MIDDLE);
-                        tv.setGravity(android.view.Gravity.RIGHT);
+                        String title = e.title + (e.dayString.isEmpty() ? "" : ",");
+                        String details = e.dayString
+                                + ((e.allDay) ? " all-day " : " at " + DateFormat.format(
+                                        DateFormat.is24HourFormat(getContext()) ? "kk:mm"
+                                                : "hh:mm a", e.begin).toString())
+                                + (!e.location.isEmpty() ? " (" + e.location + ")" : "");
+                        CalendarEntry cEntry = new CalendarEntry(getContext(), title, details, dateWidth);
+                        cEntry.setLayoutParams(new LinearLayout.LayoutParams(dateWidth, -2));
                         if (mCalendarUsingColors)
-                            tv.setTextColor(e.color);
-                        mCalendarView.addView(tv);
+                            cEntry.setColor(e.color);
+                        mCalendarView.addView(cEntry);
                     }
                     mCalendarView.setFlipInterval(interval);
                     mCalendarView.setVisibility(View.VISIBLE);
@@ -498,7 +494,7 @@ class KeyguardStatusViewManager implements OnClickListener {
                     if (!multipleEventsEnabled || mCalendarEvents.size() <= 1) {
                         mCalendarView.stopFlipping();
                     } else {
-                        Log.d(TAG, "multiple events, flip that shit");
+                        Log.d(TAG, "multiple events, flipping");
                         mCalendarView.startFlipping();
                     }
                 } else {
@@ -551,9 +547,9 @@ class KeyguardStatusViewManager implements OnClickListener {
                     string = getContext().getString(R.string.lockscreen_low_battery);
                     icon.value = BATTERY_LOW_ICON;
                     if (mLockAlwaysBattery) {
-                        // Show battery at low percent	
+                        // Show battery at low percent
                         string = getContext().getString(R.string.lockscreen_always_battery,
-                        icon.value = BATTERY_LOW_ICON);
+                                icon.value = BATTERY_LOW_ICON);
                     }
                 } else {
                     // Always show battery
@@ -592,9 +588,9 @@ class KeyguardStatusViewManager implements OnClickListener {
                     string = getContext().getString(R.string.lockscreen_low_battery);
                     icon.value = BATTERY_LOW_ICON;
                     if (mLockAlwaysBattery) {
-                        // Show battery at low percent	
+                        // Show battery at low percent
                         string = getContext().getString(R.string.lockscreen_always_battery,
-                        icon.value = BATTERY_LOW_ICON);
+                                icon.value = BATTERY_LOW_ICON);
                     }
                 } else {
                     // Always show battery
@@ -936,10 +932,10 @@ class KeyguardStatusViewManager implements OnClickListener {
         try {
             if (!mCalendarUsingColors) {
                 for (int i = 0; i < mCalendarView.getChildCount(); i++) {
-                    ((TextView) mCalendarView.getChildAt(i)).setTextColor(color);
+                    ((CalendarEntry) mCalendarView.getChildAt(i)).setColor(color);
                 }
                 if (DEBUG)
-                    Log.d(TAG, String.format("Setting mWeatherView DATE text color to %d", color));
+                    Log.d(TAG, String.format("Setting mCalendarView DATE text color to %d", color));
             }
         } catch (NullPointerException ne) {
             if (DEBUG)
@@ -1034,11 +1030,10 @@ class KeyguardStatusViewManager implements OnClickListener {
             if (beginDay == today) { // today
                 dayString = "";
             } else if (today + 1 == beginDay || (today >= 365 && beginDay == 1)) { // tomorrow
-                dayString = ", Tomorrow";
+                dayString = "Tomorrow";
             } else { // another day of week
-                dayString = ", "
-                        + begin.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.LONG,
-                                Locale.getDefault());
+                dayString = begin.getDisplayName(Calendar.DAY_OF_WEEK, Calendar.SHORT,
+                        Locale.getDefault());
             }
             allDay = a;
             color = c;

--- a/policy/src/com/android/internal/policy/impl/WeatherText.java
+++ b/policy/src/com/android/internal/policy/impl/WeatherText.java
@@ -43,6 +43,8 @@ public class WeatherText extends TextView {
     public WeatherText(Context context, AttributeSet attrs) {
         super(context, attrs);
         setText("");
+        ContentResolver resolver = mContext.getContentResolver();
+        showLocation = Settings.System.getInt(resolver, Settings.System.WEATHER_SHOW_LOCATION, 0) == 1;
     }
 
     @Override
@@ -52,8 +54,6 @@ public class WeatherText extends TextView {
             mAttached = true;
             IntentFilter filter = new IntentFilter("com.aokp.romcontrol.INTENT_WEATHER_UPDATE");
             getContext().registerReceiver(weatherReceiver, filter, null, getHandler());
-
-            SettingsObserver so = new SettingsObserver(getHandler());
         }
     }
 
@@ -65,36 +65,4 @@ public class WeatherText extends TextView {
             mAttached = false;
         }
     }
-
-    class SettingsObserver extends ContentObserver {
-        SettingsObserver(Handler handler) {
-            super(handler);
-            observe();
-        }
-
-        void observe() {
-            ContentResolver resolver = mContext.getContentResolver();
-            resolver.registerContentObserver(
-                    Settings.System.getUriFor(Settings.System.USE_WEATHER), false,
-                    this);
-            resolver.registerContentObserver(
-                    Settings.System.getUriFor(Settings.System.WEATHER_SHOW_LOCATION), false,
-                    this);
-            updateSettings();
-        }
-
-        @Override
-        public void onChange(boolean selfChange) {
-            updateSettings();
-        }
-    }
-
-    protected void updateSettings() {
-        ContentResolver resolver = mContext.getContentResolver();
-        
-        boolean useWeather = Settings.System.getInt(resolver, Settings.System.USE_WEATHER, 0) == 1;
-        showLocation = Settings.System.getInt(resolver, Settings.System.WEATHER_SHOW_LOCATION, 0) == 1;
-        setVisibility(useWeather ? View.VISIBLE : View.GONE);
-    }
-
 }


### PR DESCRIPTION
this class allows us to truncate the calendar text nicely:
cut text only from the end of the event title, not just from "the middle of the textview"
