### PR TITLE
Fix "call of overloaded enforceInterface"

### DIFF
--- a/include/binder/Parcel.h
+++ b/include/binder/Parcel.h
@@ -76,9 +76,7 @@ public:
     // passed in.
     bool                enforceInterface(const String16& interface,
                                          IPCThreadState* threadState = NULL) const;
-#ifdef _INTERNAL_BINDER_PARCEL_
-    bool                enforceInterface(const String16& interface) const;
-#endif
+
     bool                checkInterface(IBinder*) const;
 
     void                freeData();


### PR DESCRIPTION
This will fix the compilation error with all ubuntu distro "call of overloaded enforceInterface" because of duplicate.
